### PR TITLE
Fix enabling movement on clients in a multiplayer game.

### DIFF
--- a/Source/PsRealVehiclePlugin/Private/PrvVehicleMovementComponent.cpp
+++ b/Source/PsRealVehiclePlugin/Private/PrvVehicleMovementComponent.cpp
@@ -265,13 +265,6 @@ void UPrvVehicleMovementComponent::TickComponent(float DeltaTime, enum ELevelTic
 		// Perform full simulation only on server and for local owner
 		if (ShouldAddForce())
 		{
-			// Reset input if movement is disabled
-			if (!bIsMovementEnabled)
-			{
-				SetSteeringInput(0.f);
-				SetThrottleInput(0.f);
-			}
-
 			// Suspension
 			UpdateSuspension(DeltaTime);
 			UpdateFriction(DeltaTime);
@@ -2097,6 +2090,12 @@ bool UPrvVehicleMovementComponent::ApplyRigidBodyState(const FRigidBodyState& Ne
 
 void UPrvVehicleMovementComponent::SetThrottleInput(float Throttle)
 {
+	if (!bIsMovementEnabled)
+	{
+		RawThrottleInput = 0.0f;
+		return;
+	}
+
 	float NewThrottle = FMath::Clamp(Throttle, -1.0f, 1.0f);
 	
 	if (bSteeringStabilizerActiveLeft || bSteeringStabilizerActiveRight)
@@ -2109,6 +2108,12 @@ void UPrvVehicleMovementComponent::SetThrottleInput(float Throttle)
 
 void UPrvVehicleMovementComponent::SetSteeringInput(float Steering)
 {
+	if (!bIsMovementEnabled)
+	{
+		RawSteeringInput = 0.0f;
+		return;
+	}
+
 	float NewSteering = FMath::Clamp(Steering, -1.0f, 1.0f);
 	
 	RawSteeringInput = NewSteering;
@@ -2127,6 +2132,8 @@ void UPrvVehicleMovementComponent::EnableMovement()
 void UPrvVehicleMovementComponent::DisableMovement()
 {
 	bIsMovementEnabled = false;
+	SetSteeringInput(0.0f);
+	SetThrottleInput(0.0f);
 }
 
 bool UPrvVehicleMovementComponent::IsMoving() const


### PR DESCRIPTION
Before that if movement was disabled and we enable movement while trying to move then vehicle wouldn't move until we change throttle value. It's because client thought that throttle value haven't changed. It's because ShouldAddForce have checks about authority role and returns false in case of client.
If player had authority role then vehicle would move after enabling movement in this case.